### PR TITLE
fix/backend-generate-phrases

### DIFF
--- a/backend/src/main/java/br/com/challenge/alura/phrases/random/services/ChatGPTService.java
+++ b/backend/src/main/java/br/com/challenge/alura/phrases/random/services/ChatGPTService.java
@@ -30,11 +30,11 @@ public class ChatGPTService {
 	 * @since Tuesday, 5th November 2024
 	 * */
 	public String generatePhraseByPerson(Frase frase) {
-		final var promptReq = "Me mostre uma frase dita pelo(a) personagem %s da série %s, trazendo apenas a frase em protuguês BR sem precisar explicar seu significado."
+		final var promptReq = "Me mostre uma frase clássica dita pelo(a) personagem %s da série ou filme %s, trazendo apenas a frase em protuguês BR sem precisar explicar seu significado."
 				.formatted(frase.personagem(), frase.titulo());
 
 		try {
-			return generateByOpenAI(promptReq).replace("\n", "");
+			return generateByOpenAI(promptReq).replaceAll("[\n\"]", "");
 
 		} catch (Exception e) {
 			throw new InformationProcessingException(
@@ -53,11 +53,11 @@ public class ChatGPTService {
 	 * @since Tuesday, 5th November 2024
 	 * */
 	public List<String> generatePersonsBySeriesTitle(String title, Integer limit) {
-		final var prompt = "Liste os nomes completos dos %d principais personagens da série %s separados por virgula (,) em uma única linha"
+		final var prompt = "Liste os nomes completos de %d personagens da série ou filme %s separados por virgula (,) em uma única linha"
 				.formatted(limit, title);
 		try {
 			final String generated = generateByOpenAI(prompt);
-			return Arrays.stream(generated.replace("\n", "").split(", ")).collect(Collectors.toList());
+			return Arrays.stream(generated.replaceAll("\n", "").split(", ")).collect(Collectors.toList());
 
 		} catch (Exception e) {
 			throw new InformationProcessingException(

--- a/backend/src/main/java/br/com/challenge/alura/phrases/random/services/FraseService.java
+++ b/backend/src/main/java/br/com/challenge/alura/phrases/random/services/FraseService.java
@@ -61,6 +61,9 @@ public class FraseService {
 					"Não foi possivel encontrar a série com o titulo (%s) informado.".formatted(title)
 				);
 			}
+		} else {
+			final var serieFounded = founded.get();
+			serie = Optional.of( new OMDBSerieDTO(serieFounded.titulo(), serieFounded.poster()) );
 		}
 
 		final var persons = gptService.generatePersonsBySeriesTitle(title, limit);


### PR DESCRIPTION
# 📃 Fix Backend Generate Phrases
🚩Fix<br>
📅Quinta-feira, 7 de novembro de 2024<br>

Correção dos prompts para aceitar tanto filmes quanto séries, além de melhorar o resultado das frases dos personagens de determinado titulo informado para gerar uma quantidade especifica de frases de personagens.

Correção da geração de frases quando filme/série existente na base de dados retornando ao cliente séries nulas.
